### PR TITLE
Add Claude Prime page and navigation link

### DIFF
--- a/ClaudePrime/index.html
+++ b/ClaudePrime/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Claude Prime</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-black text-white font-sans">
+  <header class="bg-gray-900 p-6 border-b border-gray-700">
+    <div class="max-w-5xl mx-auto flex flex-wrap items-center justify-between">
+      <h1 class="text-3xl font-bold"><a href="../index.html">Jewel City Nexus</a></h1>
+      <nav class="flex flex-wrap gap-4 text-gray-300">
+        <a href="../index.html" class="hover:text-white">Home</a>
+        <a href="../genesis.html" class="hover:text-white">Genesis</a>
+        <a href="../assessment.html" class="hover:text-white">Assessment</a>
+        <a href="../consulting.html" class="hover:text-white">Consulting</a>
+        <a href="../grants.html" class="hover:text-white">Grants</a>
+        <a href="../store.html" class="hover:text-white">Store</a>
+        <a href="../ClaudePrime/" class="hover:text-white">Claude Prime</a>
+        <a href="../contact.html" class="hover:text-white">Contact</a>
+      </nav>
+    </div>
+  </header>
+  <main class="min-h-screen">
+    <iframe src="https://claude.ai/share/60db4ccf-f4bb-43fa-81d6-30acbc9c9f4b" class="w-full h-screen" title="Claude Prime Content"></iframe>
+    <div class="p-4 text-center">
+      <p>If the content does not load, <a href="https://claude.ai/share/60db4ccf-f4bb-43fa-81d6-30acbc9c9f4b" class="text-blue-400 underline" target="_blank" rel="noopener">view it directly on Claude.ai</a>.</p>
+    </div>
+  </main>
+  <footer class="border-t border-gray-800 py-8 text-center text-gray-600 text-sm">
+    <p>&copy; 2025 Jewel City Nexus. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <a href="consulting.html" class="hover:text-white">Consulting</a>
         <a href="grants.html" class="hover:text-white">Grants</a>
         <a href="store.html" class="hover:text-white">Store</a>
+        <a href="ClaudePrime/" class="hover:text-white">Claude Prime</a>
         <a href="contact.html" class="hover:text-white">Contact</a>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- add new Claude Prime page embedding the provided Claude.ai share link
- link to Claude Prime page from the home navigation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891a3e73f688329b412b8467671229a